### PR TITLE
Disentanglement of databases

### DIFF
--- a/app.ini.example
+++ b/app.ini.example
@@ -15,6 +15,13 @@ schema=XXXXXXXXXX
 user=XXXXX
 password=XXXXX
 
+[corpus-db]
+host=XXXXXXXXX
+port=####
+schema=XXXXXXXXXX
+user=XXXXX
+password=XXXXX
+
 [twitter]
 consumer_key=XXXXXXXXXXXXXXXXXXXXX
 consumer_secret=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/app.ini.example
+++ b/app.ini.example
@@ -14,8 +14,9 @@ port=####
 schema=XXXXXXXXXX
 user=XXXXX
 password=XXXXX
+corpus=CORPUS_ID
 
-[corpus-db]
+[corpus-CORPUS_ID]
 host=XXXXXXXXX
 port=####
 schema=XXXXXXXXXX

--- a/corpus_schema.sql
+++ b/corpus_schema.sql
@@ -126,3 +126,12 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8$$
 
+delimiter $$
+
+CREATE TABLE `corpus_info` (
+  `id` varchar(45) NOT NULL,
+  `description` varchar(250) DEFAULT NULL,
+  `created` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4$$
+

--- a/corpus_schema.sql
+++ b/corpus_schema.sql
@@ -1,0 +1,128 @@
+delimiter $$
+
+CREATE TABLE `burst_keywords` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `mid_point` datetime NOT NULL,
+  `window_size` int(11) NOT NULL,
+  `before_total_words` int(11) NOT NULL,
+  `after_total_words` int(11) NOT NULL,
+  `term` varchar(32) NOT NULL,
+  `before_count` int(11) NOT NULL,
+  `after_count` int(11) NOT NULL,
+  `count_delta` int(11) NOT NULL,
+  `count_percent_delta` float NOT NULL,
+  `before_rate` float NOT NULL,
+  `after_rate` float NOT NULL,
+  `rate_delta` float NOT NULL,
+  `rate_percent_delta` float NOT NULL,
+  `before_relevance` float NOT NULL,
+  `after_relevance` float NOT NULL,
+  `relevance_delta` float NOT NULL,
+  `relevance_percent_delta` float NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=28539 DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `conversations` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `breadth` int(11) DEFAULT NULL,
+  `depth` int(11) DEFAULT NULL,
+  `root_tweet` bigint(20) DEFAULT NULL,
+  `tweet_count` int(11) DEFAULT NULL,
+  `start` datetime DEFAULT NULL,
+  `end` datetime DEFAULT NULL,
+  `users_count` int(11) DEFAULT NULL,
+  `retweet_count` int(11) DEFAULT NULL,
+  `sentiment` float(10,9) DEFAULT NULL,
+  `abs_sentiment` float DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `root_tweet` (`root_tweet`)
+) ENGINE=MyISAM AUTO_INCREMENT=315221 DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `hashtag_uses` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `tweet_id` bigint(20) unsigned NOT NULL,
+  `hashtag_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `hashtag_id` (`hashtag_id`),
+  KEY `tweet_id` (`tweet_id`),
+  KEY `secondary` (`tweet_id`,`hashtag_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=6808690 DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `hashtags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `string` varchar(150) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `string` (`string`)
+) ENGINE=MyISAM AUTO_INCREMENT=294782 DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `mentions` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `tweet_id` bigint(20) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `tweet_id` (`tweet_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=5742381 DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `tweets` (
+  `id` bigint(20) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `created_at` datetime NOT NULL,
+  `in_reply_to_status_id` bigint(20) unsigned DEFAULT NULL,
+  `in_reply_to_user_id` int(11) DEFAULT NULL,
+  `retweet_of_status_id` bigint(20) DEFAULT NULL,
+  `text` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  `followers_count` int(11) NOT NULL,
+  `friends_count` int(11) NOT NULL,
+  `sentiment` int(11) DEFAULT NULL,
+  `is_retweet` tinyint(1) NOT NULL,
+  `is_reply` tinyint(1) NOT NULL,
+  `conversation_id` int(10) unsigned DEFAULT NULL,
+  `depth` int(11) unsigned DEFAULT NULL,
+  `retweet_count` int(11) NOT NULL,
+  `child_count` int(11) DEFAULT NULL,
+  `created_at_5s` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`),
+  KEY `created_at` (`created_at`),
+  KEY `is_retweet` (`is_retweet`),
+  KEY `is_reply` (`is_reply`),
+  KEY `conversation_id` (`conversation_id`),
+  KEY `sentiment` (`sentiment`),
+  KEY `retweet_count` (`retweet_count`),
+  KEY `created_at_5s` (`created_at_5s`),
+  KEY `filters_users` (`is_retweet`,`created_at_5s`,`user_id`),
+  KEY `filters` (`is_retweet`,`created_at_5s`,`sentiment`,`retweet_count`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8$$
+
+
+delimiter $$
+
+CREATE TABLE `users` (
+  `id` int(11) NOT NULL,
+  `screen_name` varchar(100) NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `location` varchar(150) DEFAULT NULL,
+  `utc_offset` int(11) DEFAULT NULL,
+  `lang` varchar(15) DEFAULT NULL,
+  `time_zone` varchar(150) DEFAULT NULL,
+  `statuses_count` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8$$
+

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,7 @@
 delimiter $$
 
+delimiter $$
+
 CREATE TABLE `annotations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created` datetime NOT NULL,
@@ -7,9 +9,10 @@ CREATE TABLE `annotations` (
   `label` varchar(150) NOT NULL,
   `time` datetime NOT NULL,
   `public` int(1) unsigned NOT NULL DEFAULT '1',
+  `corpus` varchar(45) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `public_time` (`public`,`time`)
-) ENGINE=MyISAM AUTO_INCREMENT=68 DEFAULT CHARSET=utf8mb4$$
+) ENGINE=MyISAM AUTO_INCREMENT=78 DEFAULT CHARSET=utf8mb4$$
 
 
 delimiter $$
@@ -18,9 +21,10 @@ CREATE TABLE `discussions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created` datetime NOT NULL,
   `public` int(1) unsigned NOT NULL DEFAULT '1',
+  `corpus` varchar(45) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `public` (`public`)
-) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4$$
+) ENGINE=MyISAM AUTO_INCREMENT=42 DEFAULT CHARSET=utf8mb4$$
 
 
 delimiter $$
@@ -34,8 +38,9 @@ CREATE TABLE `instrumentation` (
   `data` varchar(250) DEFAULT NULL,
   `ref_id` int(11) DEFAULT NULL,
   `public` int(10) unsigned NOT NULL DEFAULT '1',
+  `corpus` varchar(45) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=3723 DEFAULT CHARSET=utf8mb4$$
+) ENGINE=MyISAM AUTO_INCREMENT=5580 DEFAULT CHARSET=utf8mb4$$
 
 
 delimiter $$
@@ -75,4 +80,14 @@ CREATE TABLE `app_users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_twitter_id` (`twitter_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4$$
+
+
+delimiter $$
+
+CREATE TABLE `corpora` (
+  `id` varchar(45) NOT NULL,
+  `name` varchar(150) NOT NULL,
+  `created` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4$$
 

--- a/schema.sql
+++ b/schema.sql
@@ -14,50 +14,6 @@ CREATE TABLE `annotations` (
 
 delimiter $$
 
-CREATE TABLE `burst_keywords` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `mid_point` datetime NOT NULL,
-  `window_size` int(11) NOT NULL,
-  `before_total_words` int(11) NOT NULL,
-  `after_total_words` int(11) NOT NULL,
-  `term` varchar(32) NOT NULL,
-  `before_count` int(11) NOT NULL,
-  `after_count` int(11) NOT NULL,
-  `count_delta` int(11) NOT NULL,
-  `count_percent_delta` float NOT NULL,
-  `before_rate` float NOT NULL,
-  `after_rate` float NOT NULL,
-  `rate_delta` float NOT NULL,
-  `rate_percent_delta` float NOT NULL,
-  `before_relevance` float NOT NULL,
-  `after_relevance` float NOT NULL,
-  `relevance_delta` float NOT NULL,
-  `relevance_percent_delta` float NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=28539 DEFAULT CHARSET=utf8$$
-
-
-delimiter $$
-
-CREATE TABLE `conversations` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `breadth` int(11) DEFAULT NULL,
-  `depth` int(11) DEFAULT NULL,
-  `root_tweet` bigint(20) DEFAULT NULL,
-  `tweet_count` int(11) DEFAULT NULL,
-  `start` datetime DEFAULT NULL,
-  `end` datetime DEFAULT NULL,
-  `users_count` int(11) DEFAULT NULL,
-  `retweet_count` int(11) DEFAULT NULL,
-  `sentiment` float(10,9) DEFAULT NULL,
-  `abs_sentiment` float DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `root_tweet` (`root_tweet`)
-) ENGINE=MyISAM AUTO_INCREMENT=315221 DEFAULT CHARSET=utf8$$
-
-
-delimiter $$
-
 CREATE TABLE `discussions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created` datetime NOT NULL,
@@ -65,29 +21,6 @@ CREATE TABLE `discussions` (
   PRIMARY KEY (`id`),
   KEY `public` (`public`)
 ) ENGINE=MyISAM AUTO_INCREMENT=35 DEFAULT CHARSET=utf8mb4$$
-
-
-delimiter $$
-
-CREATE TABLE `hashtag_uses` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `tweet_id` bigint(20) unsigned NOT NULL,
-  `hashtag_id` int(10) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `hashtag_id` (`hashtag_id`),
-  KEY `tweet_id` (`tweet_id`),
-  KEY `secondary` (`tweet_id`,`hashtag_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6808690 DEFAULT CHARSET=utf8$$
-
-
-delimiter $$
-
-CREATE TABLE `hashtags` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `string` varchar(150) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `string` (`string`)
-) ENGINE=MyISAM AUTO_INCREMENT=294782 DEFAULT CHARSET=utf8$$
 
 
 delimiter $$
@@ -107,18 +40,6 @@ CREATE TABLE `instrumentation` (
 
 delimiter $$
 
-CREATE TABLE `mentions` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `tweet_id` bigint(20) unsigned NOT NULL,
-  `user_id` int(10) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `tweet_id` (`tweet_id`),
-  KEY `user_id` (`user_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=5742381 DEFAULT CHARSET=utf8$$
-
-
-delimiter $$
-
 CREATE TABLE `messages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `discussion_id` int(11) NOT NULL,
@@ -130,55 +51,6 @@ CREATE TABLE `messages` (
   KEY `created` (`created`)
 ) ENGINE=MyISAM AUTO_INCREMENT=164 DEFAULT CHARSET=utf8mb4$$
 
-
-delimiter $$
-
-CREATE TABLE `tweets` (
-  `id` bigint(20) unsigned NOT NULL,
-  `user_id` int(10) unsigned NOT NULL,
-  `created_at` datetime NOT NULL,
-  `in_reply_to_status_id` bigint(20) unsigned DEFAULT NULL,
-  `in_reply_to_user_id` int(11) DEFAULT NULL,
-  `retweet_of_status_id` bigint(20) DEFAULT NULL,
-  `text` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
-  `followers_count` int(11) NOT NULL,
-  `friends_count` int(11) NOT NULL,
-  `sentiment` int(11) DEFAULT NULL,
-  `is_retweet` tinyint(1) NOT NULL,
-  `is_reply` tinyint(1) NOT NULL,
-  `conversation_id` int(10) unsigned DEFAULT NULL,
-  `depth` int(11) unsigned DEFAULT NULL,
-  `retweet_count` int(11) NOT NULL,
-  `child_count` int(11) DEFAULT NULL,
-  `created_at_5s` int(10) unsigned DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `created_at` (`created_at`),
-  KEY `is_retweet` (`is_retweet`),
-  KEY `is_reply` (`is_reply`),
-  KEY `conversation_id` (`conversation_id`),
-  KEY `sentiment` (`sentiment`),
-  KEY `retweet_count` (`retweet_count`),
-  KEY `created_at_5s` (`created_at_5s`),
-  KEY `filters_users` (`is_retweet`,`created_at_5s`,`user_id`),
-  KEY `filters` (`is_retweet`,`created_at_5s`,`sentiment`,`retweet_count`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8$$
-
-
-delimiter $$
-
-CREATE TABLE `users` (
-  `id` int(11) NOT NULL,
-  `screen_name` varchar(100) NOT NULL,
-  `name` varchar(100) NOT NULL,
-  `created_at` datetime DEFAULT NULL,
-  `location` varchar(150) DEFAULT NULL,
-  `utc_offset` int(11) DEFAULT NULL,
-  `lang` varchar(15) DEFAULT NULL,
-  `time_zone` varchar(150) DEFAULT NULL,
-  `statuses_count` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8$$
 
 delimiter $$
 

--- a/util/queries.inc.php
+++ b/util/queries.inc.php
@@ -26,6 +26,7 @@ class Queries
      * @var PDO
      */
     private $corpus;
+    private $corpus_id;
     //The value used to filter user generated content
     private $public = 1;
     private $logging_enabled = 1;
@@ -76,12 +77,24 @@ class Queries
         $pdo_string = "mysql:host=${params['host']};dbname=${params['schema']};port=${params['port']}";
 
         //Create a persistent PDO connection
-        $this->db = new PDO($pdo_string, $params['user'], $params['password'], array(
-            PDO::ATTR_PERSISTENT => true
-        ));
+        try {
+            $this->db = new PDO($pdo_string, $params['user'], $params['password'], array(
+                PDO::ATTR_PERSISTENT => true
+            ));
+        } catch (PDOException $e) {
+            echo 'Connection failed: ' . $e->getMessage();
+            die();
+        }
 
-        if (isset($config['corpus-db']) && is_array($config['corpus-db'])) {
-            $params = $config['corpus-db'];
+        $corpus_id = $params['corpus'];
+        if (!isset($config["corpus-$corpus_id"]) || !is_array($config["corpus-$corpus_id"])) {
+            //Re-use the same connection and hope the data is there! this should not be used in production
+            $this->corpus_id = 'self';
+            $this->corpus = $this->db;
+        } else {
+            $this->corpus_id = $corpus_id;
+
+            $params = $config["corpus-$corpus_id"];
 
             //Load a second database connection for the corpus data
             if (!array_key_exists('port', $params)) {
@@ -91,12 +104,14 @@ class Queries
             $pdo_string = "mysql:host=${params['host']};dbname=${params['schema']};port=${params['port']}";
 
             //Create a persistent PDO connection
-            $this->corpus = new PDO($pdo_string, $params['user'], $params['password'], array(
-                PDO::ATTR_PERSISTENT => true
-            ));
-        } else {
-            //Reuse the first connection
-            $this->corpus = $this->db;
+            try {
+                $this->corpus = new PDO($pdo_string, $params['user'], $params['password'], array(
+                    PDO::ATTR_PERSISTENT => true
+                ));
+            } catch (PDOException $e) {
+                echo 'Connection failed: ' . $e->getMessage();
+                die();
+            }
         }
 
         $this->build_queries();
@@ -104,6 +119,8 @@ class Queries
         $this->set_encoding();
 
         $this->session_handler = new DbSessionHandler($this, $config);
+
+        $this->check_corpus();
     }
 
     /**
@@ -171,6 +188,47 @@ class Queries
         $this->db->query('set names utf8mb4');
         if ($this->corpus !== $this->db) {
             $this->corpus->query('set names utf8mb4');
+        }
+    }
+
+    private function _build_corpus_check()
+    {
+        $this->prepare('corpus_info',
+            "SELECT * FROM corpus_info
+             WHERE id=?",
+            's',
+            $this->corpus
+        );
+
+        $this->prepare('corpora',
+            "SELECT * FROM corpora
+             WHERE id=?",
+            's',
+            $this->db
+        );
+
+        $this->prepare('insert_corpus',
+            'INSERT INTO corpora (id, name, created)
+            VALUES (?, ?, NOW())',
+            'ss',
+            $this->db
+        );
+    }
+
+    private function check_corpus()
+    {
+        //First make sure the corpus we are connected to is actually the one we think
+        //we are connected to.
+        $result = $this->run('corpus_info', $this->corpus_id);
+        if (!$result || count($result) != 1) {
+            echo 'Not connected to corpus ' . $this->corpus_id;
+            die();
+        }
+
+        //Make sure the corpus is registered in the app db
+        $result = $this->run('corpora', $this->corpus_id);
+        if (!is_array($result) || count($result) != 1) {
+            $this->run('insert_corpus', $this->corpus_id, $this->corpus_id . ' (auto)');
         }
     }
 
@@ -334,9 +392,9 @@ class Queries
     private function _build_log_action()
     {
         $this->prepare('log_action',
-            "INSERT INTO instrumentation (time, ip_address, action, user, data, ref_id, public)
-            VALUES (NOW(), ?, ?, ?, ?, ?, ?)",
-            'ssssii',
+            "INSERT INTO instrumentation (time, ip_address, action, user, data, ref_id, public, corpus)
+            VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?)",
+            'ssssiis',
             $this->db
         );
     }
@@ -361,15 +419,15 @@ class Queries
             $user = $user_data->id;
         }
 
-        $this->run('log_action', $ip_address, $action, $user, $data, $reference_id, $this->public);
+        $this->run('log_action', $ip_address, $action, $user, $data, $reference_id, $this->public, $this->corpus_id);
     }
 
     private function _build_insert_annotation()
     {
         $this->prepare('insert_annotation',
-            "INSERT INTO annotations (created, user, label, time, public)
-            VALUES (?, ?, ?, ?, ?)",
-            'ssssi',
+            "INSERT INTO annotations (created, user, label, time, public, corpus)
+            VALUES (?, ?, ?, ?, ?, ?)",
+            'ssssis',
             $this->db
         );
     }
@@ -389,7 +447,7 @@ class Queries
 
         $datetime = $datetime->format('Y-m-d H:i:s');
 
-        $this->run('insert_annotation', $created, $user, $label, $datetime, $this->public);
+        $this->run('insert_annotation', $created, $user, $label, $datetime, $this->public, $this->corpus_id);
         return $this->db->lastInsertId();
     }
 
@@ -426,24 +484,26 @@ class Queries
 
         $binder = new Binder();
         $public = $binder->param('public', $this->public, PDO::PARAM_INT);
+        $corpus = $binder->param('corpus', $this->corpus_id);
 
         $builder->where("a.public", "=", $public);
+        $builder->where("a.corpus", "=", $corpus);
         return $this->run2($builder, $binder, $this->db);
     }
 
     private function _build_insert_message()
     {
         $this->prepare('insert_message',
-            "INSERT INTO messages (created, user, message, view_state, discussion_id)
-            VALUES (?, ?, ?, ?, ?)",
-            'ssssi',
+            "INSERT INTO messages (created, user, message, view_state, discussion_id, corpus)
+            VALUES (?, ?, ?, ?, ?, ?)",
+            'ssssis',
             $this->db
         );
 
         $this->prepare('insert_discussion',
-            "INSERT INTO discussions (created, public)
-            VALUES (?, ?)",
-            'si',
+            "INSERT INTO discussions (created, public, corpus)
+            VALUES (?, ?, ?)",
+            'sis',
             $this->db
         );
     }
@@ -463,11 +523,11 @@ class Queries
         $time = $now->format('Y-m-d H:i:s');
 
         if (!$discussion_id) {
-            $this->run('insert_discussion', $time, $this->public);
+            $this->run('insert_discussion', $time, $this->public, $this->corpus_id);
             $discussion_id = $this->db->lastInsertId();
         }
 
-        $this->run('insert_message', $time, $user, $message, $view_state, $discussion_id);
+        $this->run('insert_message', $time, $user, $message, $view_state, $discussion_id, $this->corpus_id);
         return $this->db->lastInsertId();
     }
 
@@ -476,8 +536,8 @@ class Queries
         $this->prepare('message',
             "SELECT messages.*, UNIX_TIMESTAMP(created) AS created
              FROM messages
-             WHERE id = ?",
-            'i',
+             WHERE id = ? AND corpus = ?",
+            'is',
             $this->db
         );
     }
@@ -490,7 +550,7 @@ class Queries
      */
     public function get_message($message_id)
     {
-        $result = $this->run('message', $message_id);
+        $result = $this->run('message', $message_id, $this->corpus_id);
 
         if (count($result) > 0) {
             $row = $result[0];
@@ -576,8 +636,11 @@ class Queries
 
         $binder = new Binder();
         $public = $binder->param('public', $this->public);
+        $corpus = $binder->param('corpus', $this->corpus_id);
 
         $builder->where('d.public', '=', $public);
+        $builder->where("d.corpus", "=", $corpus);
+
         $builder->group_by('m.discussion_id');
         $builder->order_by('last_comment_at', 'desc');
 

--- a/util/queries.inc.php
+++ b/util/queries.inc.php
@@ -80,8 +80,8 @@ class Queries
             PDO::ATTR_PERSISTENT => true
         ));
 
-        if (isset($config['corpus']) && is_array($config['corpus'])) {
-            $params = $config['corpus'];
+        if (isset($config['corpus-db']) && is_array($config['corpus-db'])) {
+            $params = $config['corpus-db'];
 
             //Load a second database connection for the corpus data
             if (!array_key_exists('port', $params)) {

--- a/util/queries.inc.php
+++ b/util/queries.inc.php
@@ -494,9 +494,9 @@ class Queries
     private function _build_insert_message()
     {
         $this->prepare('insert_message',
-            "INSERT INTO messages (created, user, message, view_state, discussion_id, corpus)
-            VALUES (?, ?, ?, ?, ?, ?)",
-            'ssssis',
+            "INSERT INTO messages (created, user, message, view_state, discussion_id)
+            VALUES (?, ?, ?, ?, ?)",
+            'ssssi',
             $this->db
         );
 
@@ -527,7 +527,7 @@ class Queries
             $discussion_id = $this->db->lastInsertId();
         }
 
-        $this->run('insert_message', $time, $user, $message, $view_state, $discussion_id, $this->corpus_id);
+        $this->run('insert_message', $time, $user, $message, $view_state, $discussion_id);
         return $this->db->lastInsertId();
     }
 
@@ -536,8 +536,8 @@ class Queries
         $this->prepare('message',
             "SELECT messages.*, UNIX_TIMESTAMP(created) AS created
              FROM messages
-             WHERE id = ? AND corpus = ?",
-            'is',
+             WHERE id = ?",
+            'i',
             $this->db
         );
     }
@@ -550,7 +550,7 @@ class Queries
      */
     public function get_message($message_id)
     {
-        $result = $this->run('message', $message_id, $this->corpus_id);
+        $result = $this->run('message', $message_id);
 
         if (count($result) > 0) {
             $row = $result[0];


### PR DESCRIPTION
This includes changes to separate the read/write application-level database stuff from the read-only Twitter corpus (#108). To make this work, you add to the `db` section of your app.ini file a `corpus` variable, containing a key that uniquely references a particular corpus. Let's say you call it `sb47_s140`.

In the app.ini file, you also need to create a new section called `corpus-sb47_s140`, which must contain valid database connection settings pointing to the twitter corpus referred to as `sb47_s140`. Note that your ini file can contain multiple sections like this, but only may refer to one at a time in the `corpus` setting.

When the PHP script `queries.inc.php` runs, it connects first to the main `db` connection. Then, it tries to connect to the corpus database. Once connected, it verifies that the corpus database thinks it's name matches the one you are using (there is a new `corpus_info` table in the corpus database schema).

The queries in `queries.inc.php` now refer to either `$this->db` or `$this->corpus`, depending which database they need. The user-generated content also references a specific corpus id, and only content pertinent to the id currently in use is displayed.

The schema is documented in `corpus_schema.sql` and `schema.sql`.

Future work includes allowing users to switch between different configured corpora in the UI.
