### PR TITLE
Simple sign in option

### DIFF
--- a/app.ini.example
+++ b/app.ini.example
@@ -9,6 +9,9 @@ public=0
 ; Use SSL
 secure=true
 
+; auth_mode can be either 'simple' or 'twitter'
+auth_mode=simple
+
 ; optional IDs for Google Analytics
 [google]
 id=UA-XXXXXXXX-X

--- a/auth.php
+++ b/auth.php
@@ -1,15 +1,13 @@
 <?php
 
 include_once 'util/request.inc.php';
-include_once 'util/twitter.inc.php';
+
 
 $request = new Request('app.ini');
 $db = $request->db();
 
-$twitter_api = new TwitterAPI($request);
-$cb = $twitter_api->cb;
+$params = $request->get(array('return_to'), array('sign_out', 'username'));
 
-$params = $request->get(array('return_to'), array('sign_out'));
 if ($params->sign_out) {
 
     $user_data = $request->user_data();
@@ -18,47 +16,83 @@ if ($params->sign_out) {
 
     $db->log_action('sign out', $user_data);
 
-} else if (! isset($_SESSION['oauth_token'])) {
-    //We need to redirect the user to Twitter to get the stuff
+} else {
 
-    // get the request token
-    $reply = $cb->oauth_requestToken(array(
-        'oauth_callback' => 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']
-    ));
+    if ($request->auth_mode() == 'twitter') {
+        include_once 'util/twitter.inc.php';
+        $twitter_api = new TwitterAPI($request);
+        $cb = $twitter_api->cb;
 
-    // store the token
-    $cb->setToken($reply->oauth_token, $reply->oauth_token_secret);
-    $_SESSION['oauth_token'] = $reply->oauth_token;
-    $_SESSION['oauth_token_secret'] = $reply->oauth_token_secret;
-    $_SESSION['oauth_verify'] = true;
+        if (! isset($_SESSION['oauth_token'])) {
+            //We need to redirect the user to Twitter to get the stuff
 
-    // redirect to auth website
-    $auth_url = $cb->oauth_authenticate();
-    header('Location: ' . $auth_url);
-    die();
+            // get the request token
+            $reply = $cb->oauth_requestToken(array(
+                'oauth_callback' => 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']
+            ));
 
-} elseif (isset($_GET['oauth_verifier']) && isset($_SESSION['oauth_verify'])) {
-    //Twitter is giving us the stuff
+            // store the token
+            $cb->setToken($reply->oauth_token, $reply->oauth_token_secret);
+            $_SESSION['oauth_token'] = $reply->oauth_token;
+            $_SESSION['oauth_token_secret'] = $reply->oauth_token_secret;
+            $_SESSION['oauth_verify'] = true;
 
-    // verify the token
-    $cb->setToken($_SESSION['oauth_token'], $_SESSION['oauth_token_secret']);
-    unset($_SESSION['oauth_verify']);
+            // redirect to auth website
+            $auth_url = $cb->oauth_authenticate();
+            header('Location: ' . $auth_url);
+            die();
 
-    // get the access token
-    $reply = $cb->oauth_accessToken(array(
-        'oauth_verifier' => $_GET['oauth_verifier']
-    ));
+        } elseif (isset($_GET['oauth_verifier']) && isset($_SESSION['oauth_verify'])) {
+            //Twitter is giving us the stuff
 
-    if ($reply) {
-        // store the token (which is different from the request token!)
-        $_SESSION['oauth_token'] = $reply->oauth_token;
-        $_SESSION['oauth_token_secret'] = $reply->oauth_token_secret;
-        $twitter_api->user_auth();
+            // verify the token
+            $cb->setToken($_SESSION['oauth_token'], $_SESSION['oauth_token_secret']);
+            unset($_SESSION['oauth_verify']);
 
-        $twitter_user = $cb->account_verifyCredentials();
+            // get the access token
+            $reply = $cb->oauth_accessToken(array(
+                'oauth_verifier' => $_GET['oauth_verifier']
+            ));
+
+            if ($reply) {
+                // store the token (which is different from the request token!)
+                $_SESSION['oauth_token'] = $reply->oauth_token;
+                $_SESSION['oauth_token_secret'] = $reply->oauth_token_secret;
+                $twitter_api->user_auth();
+
+                $twitter_user = $cb->account_verifyCredentials();
+
+                //Get the user id from the database
+                $user_id = $db->get_app_user_id($twitter_user);
+                if ($user_id) {
+                    $_SESSION['user_id'] = $user_id;
+                    $user_data = $request->user_data(TRUE);
+                    $db->log_action('sign in', $user_data);
+                } else {
+                    $error = 'Could not sign in.';
+                }
+
+            } else {
+                $error = 'Authentication failure.';
+                $db->log_action('auth fail');
+            }
+        } elseif (isset($_GET['denied'])) {
+            $error = 'Authentication did not complete.';
+            $db->log_action('auth deny');
+        }
+
+        if (isset($error)) {
+            unset($_SESSION['oauth_token']);
+            unset($_SESSION['oauth_token_secret']);
+            unset($_SESSION['oauth_verify']);
+            $request->flash($error);
+        }
+    } else {
+        //It is a simple sign-in!
+        $username = $params->username;
 
         //Get the user id from the database
-        $user_id = $db->get_app_user_id($twitter_user);
+        $user_id = $db->get_simple_app_user_id($username);
         if ($user_id) {
             $_SESSION['user_id'] = $user_id;
             $user_data = $request->user_data(TRUE);
@@ -66,21 +100,7 @@ if ($params->sign_out) {
         } else {
             $error = 'Could not sign in.';
         }
-
-    } else {
-        $error = 'Authentication failure.';
-        $db->log_action('auth fail');
     }
-} elseif (isset($_GET['denied'])) {
-    $error = 'Authentication did not complete.';
-    $db->log_action('auth deny');
-}
-
-if ($error) {
-    unset($_SESSION['oauth_token']);
-    unset($_SESSION['oauth_token_secret']);
-    unset($_SESSION['oauth_verify']);
-    $request->flash($error);
 }
 
 header('Location: ' . $params->return_to);

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -71,3 +71,10 @@
 .navbar .user-display .user-name {
   font-weight: bold;
 }
+.navbar .user-display .twitter-icon-light {
+  background-position: center;
+  background-size: 20px 20px;
+  width: 14px;
+  height: 18px;
+  vertical-align: middle;
+}

--- a/css/navbar.less
+++ b/css/navbar.less
@@ -88,5 +88,13 @@
         .user-name {
             font-weight: bold;
         }
+
+        .twitter-icon-light {
+            background-position: center;
+            background-size: 20px 20px;
+            width: 14px;
+            height: 18px;
+            vertical-align: middle;
+        }
     }
 }

--- a/elements/discussion_ui.inc.php
+++ b/elements/discussion_ui.inc.php
@@ -17,7 +17,7 @@ function sign_in_box($auth_mode)
                 Sign in with Twitter
             </button>
             <?php } else { ?>
-                <input type="text" placeholder="Make up a user name"/><br/>
+                <input type="text" class="user-input" placeholder="Make up a user name"/><br/>
                 <button type="button" class="user-submit btn btn-large btn-primary">Sign in</button>
             <?php } ?>
         </div>

--- a/elements/discussion_ui.inc.php
+++ b/elements/discussion_ui.inc.php
@@ -1,7 +1,7 @@
 <?php
 if(basename(__FILE__) == basename($_SERVER['PHP_SELF'])){exit();}
 
-function sign_in_box()
+function sign_in_box($auth_mode)
 {
     ob_start();
     ?>
@@ -11,10 +11,15 @@ function sign_in_box()
             <div class="message">Discuss this data set!</div>
         </div>
         <div class="form">
+            <?php if ($auth_mode == 'twitter') { ?>
             <button type="button" class="user-submit btn btn-large btn-primary">
                 <i class="twitter-icon-light"></i>
                 Sign in with Twitter
             </button>
+            <?php } else { ?>
+                <input type="text" placeholder="Make up a user name"/><br/>
+                <button type="button" class="user-submit btn btn-large btn-primary">Sign in</button>
+            <?php } ?>
         </div>
     </div>
     <?php

--- a/elements/nav_bar.inc.php
+++ b/elements/nav_bar.inc.php
@@ -23,7 +23,7 @@ function nav_bar()
                 </ul>
                 <div class="user-display hide fade">
                     <span class="welcome-message">
-                        Welcome, <span class="user-name"></span>!
+                        Welcome, <i class="twitter-icon-light hide" title="Signed in with Twitter"></i> <span class="user-name"></span>!
                     </span>
                     <button type="button" class="btn sign-out-button">Sign out</button>
                 </div>

--- a/index.php
+++ b/index.php
@@ -81,7 +81,7 @@ include_once 'elements/discussion_ui.inc.php';
         <div class="collaborator-wrapper col">
             <div class="collaborator padding-left show-left hide">
                 <div class="sliding-panel col">
-                    <?php echo sign_in_box() ?>
+                    <?php echo sign_in_box($request->auth_mode()) ?>
                     <?php echo discussion_box() ?>
                     <?php echo discussion_view() ?>
                 </div>

--- a/js/components/sign_in.js
+++ b/js/components/sign_in.js
@@ -11,26 +11,59 @@ define(['jquery'], function($) {
     SignIn.prototype._initUI = function() {
         this.ui = {};
 
+        var userInput = this.into.find('.user-input');
+        if (userInput.length) {
+            this.ui.userInput = userInput;
+        }
+
         this.ui.userSubmit = this.into.find('.user-submit');
     };
 
     SignIn.prototype._attachEvents = function() {
         var self = this;
+
+        if (this.ui.userInput) {
+            this.ui.userInput.on('keydown', function(e) {
+                if (e.which === 13) {
+                    e.preventDefault();
+
+                    //pressed enter
+                    self._onUserSubmitted();
+
+                    return false;
+                }
+            });
+        }
+
         this.ui.userSubmit.on('click', $.proxy(this._onUserSubmitted, this));
     };
 
     SignIn.prototype._onUserSubmitted = function() {
         var return_to = window.location.href;
         var auth_url = 'auth.php?return_to=' + encodeURIComponent(return_to);
+
+        if (this.ui.userInput) {
+            var user = $.trim(this.ui.userInput.val());
+            if (!user) {
+                this.ui.userInput.focus();
+                return;
+            }
+            auth_url = auth_url + '&username=' + encodeURIComponent(user);
+        }
+
         window.location.href = auth_url;
     };
 
     SignIn.prototype.hide = function() {
-
+        if (this.ui.userInput) {
+            this.ui.userInput.val('');
+        }
     };
 
     SignIn.prototype.show = function() {
-
+        if (this.ui.userInput) {
+            this.ui.userInput.focus();
+        }
     };
 
     return SignIn;

--- a/js/components/user_info.js
+++ b/js/components/user_info.js
@@ -23,6 +23,7 @@ define(['jquery'], function($) {
         this.ui.user_display = this.into;;
         this.ui.user_name = this.ui.user_display.find('.user-name');
         this.ui.sign_out_button = this.ui.user_display.find('.sign-out-button');
+        this.ui.twitter_icon = this.ui.user_display.find('.twitter-icon-light');
     };
 
     UserInfoView.prototype.attachEvents = function() {
@@ -37,6 +38,10 @@ define(['jquery'], function($) {
     UserInfoView.prototype.show = function() {
         if (this.isShowing()) {
             return false;
+        }
+
+        if (this.user.data.twitter_id) {
+            this.ui.twitter_icon.removeClass('hide');
         }
 
         this.ui.user_name.html(this.user.screen_name());

--- a/schema.sql
+++ b/schema.sql
@@ -72,7 +72,7 @@ CREATE TABLE `app_users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created` datetime NOT NULL,
   `last_signed_in` datetime DEFAULT NULL,
-  `twitter_id` bigint(20) unsigned NOT NULL,
+  `twitter_id` bigint(20) unsigned DEFAULT NULL,
   `screen_name` varchar(100) NOT NULL,
   `name` varchar(100) DEFAULT NULL,
   `utc_offset` int(11) DEFAULT NULL,

--- a/util/builder.inc.php
+++ b/util/builder.inc.php
@@ -72,6 +72,15 @@ class Builder
         return implode("\n", $parts);
     }
 
+    /**
+     * Raw version of where condition.
+     * @param $condition
+     */
+    public function where_condition($condition) {
+        $this->_conditions[] = $condition;
+        return $condition;
+    }
+
     public function where($field, $op, $param = NULL)
     {
         if ($param === NULL) {

--- a/util/request.inc.php
+++ b/util/request.inc.php
@@ -57,6 +57,15 @@ class Request
         }
     }
 
+    public function auth_mode()
+    {
+        if (isset($this->config['auth_mode'])) {
+            return $this->config['auth_mode'];
+        } else {
+            return 'simple';
+        }
+    }
+
     /**
      * Get a performance timer for this request.
      * @return Performance


### PR DESCRIPTION
Make twitter authentication a server-side configuration option.
Added back in some of the UI that was removed before.
There can now be 2 different kinds of users in the database. Simple users have no twitter_id, while Twitter users... have a twitter_id.
They can share the same usernames but will have different ids.
In the interface, you can see whether you are signed in with twitter or not in the upper-right-hand corner.

Watch out for possible issues like #119
